### PR TITLE
Fixed Config.class path for 1.14.3 compatiblity

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/mod/OptifineVersion.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifineVersion.java
@@ -59,7 +59,7 @@ public class OptifineVersion {
 	private static JarType getJarType(File file) throws IOException {
 		ClassNode classNode;
 		try (JarFile jarFile = new JarFile(file)) {
-			JarEntry jarEntry = jarFile.getJarEntry("Config.class"); // I hope this is enough to detect optifine
+			JarEntry jarEntry = jarFile.getJarEntry("net/optifine/Config.class"); // I hope this is enough to detect optifine
 			if (jarEntry == null) {
 				return JarType.SOMETHINGELSE;
 			}


### PR DESCRIPTION
Allows Optifabric to detect 1.14.3 versions of Optifine.